### PR TITLE
chore: 🤖 add support for ap-northeast-3 KIX

### DIFF
--- a/packages/amplify-category-api/src/provider-utils/supported-datasources.ts
+++ b/packages/amplify-category-api/src/provider-utils/supported-datasources.ts
@@ -40,6 +40,7 @@ export const supportedDataSources = {
       'ap-southeast-2',
       'ap-northeast-1',
       'ap-northeast-2',
+      'ap-northeast-3',
       'ca-central-1',
       'eu-central-1',
       'eu-north-1',

--- a/packages/amplify-e2e-core/src/configure/index.ts
+++ b/packages/amplify-e2e-core/src/configure/index.ts
@@ -27,6 +27,7 @@ export const amplifyRegions = [
   'eu-central-1',
   'ap-northeast-1',
   'ap-northeast-2',
+  'ap-northeast-3',
   'ap-southeast-1',
   'ap-southeast-2',
   'ap-south-1',


### PR DESCRIPTION
#### Description of changes
This PR enables support in ap-northeast-3 region (KIX)

##### CDK / CloudFormation Parameters Changed
N/A
#### Issue #, if available
Associated CLI PR: https://github.com/aws-amplify/amplify-cli/pull/13039

#### Description of how you validated changes
I set ap-northeast-3 in my ~/.aws/config for my amplify profile and created an app.

I ran: 
amplify-dev init
amplify-dev add api (default graphQL options)
amplify-dev push

Confirmed that an API was successfully deployed to my account in ap-northeast-3 region

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [X] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-cli/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] New AWS SDK calls or CloudFormation actions have been added to relevant test and service IAM policies
- [ ] Any CDK or CloudFormation parameter changes are called out explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
